### PR TITLE
Move elyra directories to /opt

### DIFF
--- a/roles/notebook/defaults/main.yml
+++ b/roles/notebook/defaults/main.yml
@@ -1,6 +1,7 @@
 internal:
 
   elyra_download_server: 9.30.252.137
+  elyra_install_dir: "{{ install_dir }}/elyra"
 
 
 notebook:
@@ -22,11 +23,10 @@ notebook:
 
   elyra_yarn_endpoint_host: "{{ groups['master'][0] }}"
 
-  elyra_log_directory: /var/log/elyra
-  elyra_tmp_directory: /tmp/elyra
-  elyra_run_directory: /var/run/elyra
-  elyra_runtime_directory: /var/run/elyra/runtime
-  elyra_data_directory: /var/lib/elyra
+  elyra_install_directory: "{{ internal.elyra_install_dir }}"
+  elyra_log_directory: "{{ internal.elyra_install_dir }}/log"
+  elyra_runtime_directory: "{{ internal.elyra_install_dir }}/runtime"
+  elyra_data_directory: "{{ internal.elyra_install_dir }}/data"
 
   pip: /opt/anaconda2/bin/pip
   jupyter: /opt/anaconda2/bin/jupyter

--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -90,9 +90,9 @@
      state: absent
    when: (inventory_hostname in groups['master'])
 
- - name: remove elyra run directory
+ - name: remove elyra runtime directory
    file:
-    path: "{{ notebook.elyra_run_directory }}"
+    path: "{{ notebook.elyra_runtime_directory }}"
     state: absent
 
  - name: remove elyra user
@@ -163,11 +163,10 @@
      mode: 0755
    become_user: "{{ notebook.user }}"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
  - name: create bin directory for elyra startup
    file:
-     path: "{{ install_dir }}/bin"
+     path: "{{ notebook.elyra_install_directory }}/bin"
      state: directory
      owner: "{{ notebook.user }}"
      group: "{{ notebook.user }}"
@@ -175,15 +174,6 @@
    become_user: "{{ notebook.user }}"
    ignore_errors: yes
    when: (inventory_hostname in groups['master'])
-
- - name: create elyra run directory
-   file:
-     path: "{{ notebook.elyra_run_directory }}"
-     state: directory
-     owner: "{{ notebook.user }}"
-     group: "{{ notebook.user }}"
-     mode: 0755
-   become_user: "{{ notebook.user }}"
 
  - name: create elyra runtime directory
    file:
@@ -208,7 +198,7 @@
  - name: generate elyra startup script
    template:
     src: start-elyra.sh.j2
-    dest: "{{ install_dir }}/bin/start-elyra.sh"
+    dest: "{{ notebook.elyra_install_directory }}/bin/start-elyra.sh"
     mode: 0744
     owner: "{{ notebook.user }}"
     group: "{{ notebook.user }}"

--- a/roles/notebook/templates/start-elyra.sh.j2
+++ b/roles/notebook/templates/start-elyra.sh.j2
@@ -13,8 +13,7 @@ export ELYRA_YARN_ENDPOINT=http://{{ notebook.elyra_yarn_endpoint_host }}:8088/w
 
 export ELYRA_PROXY_LAUNCH_LOG={{ notebook.elyra_log_directory }}/proxy_launch_$(timestamp).log
 
-export ELYRA_KERNEL_LAUNCH_TIMEOUT=120
-#export ELYRA_CONNECTION_FILE_MODE=socket
+export ELYRA_KERNEL_LAUNCH_TIMEOUT=40
 
 export JUPYTER_DATA_DIR={{ notebook.elyra_data_directory }}
 export JUPYTER_RUNTIME_DIR={{ notebook.elyra_runtime_directory }}
@@ -22,7 +21,7 @@ export JUPYTER_RUNTIME_DIR={{ notebook.elyra_runtime_directory }}
 START_CMD="{{ notebook.jupyter }} kernelgateway --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=600 --MappingKernelManager.cull_interval=30 --MappingKernelManager.cull_connected=True --JupyterWebsocketPersonality.list_kernels=True"
 
 LOG={{ notebook.elyra_log_directory }}/elyra_$(timestamp).log
-PIDFILE={{ notebook.elyra_run_directory }}/elyra.pid
+PIDFILE={{ notebook.elyra_runtime_directory }}/elyra.pid
 
 eval "$START_CMD > $LOG 2>&1 &"
 if [ "$?" -eq 0 ]; then


### PR DESCRIPTION
To better contain Elyra's deployment "area", we should move the `/var/{log,run,lib}/elyra` directories into the installation area `/opt/elyra`.  This pull request changes the following directory locations (**Note: the value `/opt` is represented by the global variable `install_dir`.  `/opt` is used here to simplify the discussion**):
1. `/var/run/elyra` and `/var/run/elyra/runtime` now map to `/opt/elyra/runtime`.  The start script env variable `JUPYTER_RUNTIME_DIR` will be set to this location.  This location exists on all deployed nodes.
2. `/var/lib/elyra` now maps to `/opt/elyra/data`.  This will be the location for any data that should persist across restarts.  The start script env variable `JUPYTER_DATA_DIR` will be set to this location.  This location exists only on the Elyra server (master node).
3. `/var/log/elyra` now maps to `/opt/elyra/log`.  This will be the location for log files.  This location exists on all deployed nodes since the process_launch logs are located here.

**Unrelated change:** Decreased the `ELYRA_KERNEL_LAUNCH_TIMEOUT` from `120` to `40` seconds.