### PR TITLE
Install yarn-client kernelspecs

### DIFF
--- a/roles/notebook/defaults/main.yml
+++ b/roles/notebook/defaults/main.yml
@@ -1,25 +1,26 @@
 internal:
 
   elyra_download_server: 9.30.252.137
+  elyra_download_root: dist
   elyra_install_dir: "{{ install_dir }}/elyra"
 
 
 notebook:
 
   yarn_client_package_name: yarn_api_client-0.2.4-py2.py3-none-any.whl
-  yarn_client_pip_download_location: http://{{ internal.elyra_download_server }}/dist/yarn-api-client/
+  yarn_client_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/yarn-api-client/
 
   elyra_archive_package_name: jupyter_kernel_gateway-2.0.0.dev-py2.py3-none-any.whl
-  elyra_archive_pip_download_location: http://{{ internal.elyra_download_server }}/dist/elyra/
+  elyra_archive_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra/
 
   elyra_kernelspec_package_name: elyra-kernel-specs.tar.gz
-  elyra_kernelspec_download_location: http://{{ internal.elyra_download_server }}/dist/elyra-kernel-specs/
+  elyra_kernelspec_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra-kernel-specs/
 
   notebook_archive_package_name: notebook-5.1.0.dev0-py2.py3-none-any.whl
-  notebook_archive_pip_download_location: http://{{ internal.elyra_download_server }}/dist/notebook/
+  notebook_archive_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/notebook/
 
   toree_archive_package_name: toree-0.2.0.dev1.tar.gz
-  toree_pip_download_location: http://{{ internal.elyra_download_server }}/dist/toree/
+  toree_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/toree/
 
   elyra_yarn_endpoint_host: "{{ groups['master'][0] }}"
 

--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -1,12 +1,14 @@
  # configure hadoop
- - name: configure hadoop home folder
-   shell: "sudo -u hdfs /usr/hdp/current/hadoop-client/bin/hadoop fs -mkdir /user/root"
+ - name: create hadoop home folder
+   shell: "/usr/hdp/current/hadoop-client/bin/hadoop fs -mkdir /user/root"
    ignore_errors: yes
+   become_user: hdfs
    when: (inventory_hostname in groups['master'])
 
  - name: configure hadoop home folder
-   shell: "sudo -u hdfs /usr/hdp/current/hadoop-client/bin/hadoop fs -chown root /user/root"
+   shell: "/usr/hdp/current/hadoop-client/bin/hadoop fs -chown root /user/root"
    ignore_errors: yes
+   become_user: hdfs
    when: (inventory_hostname in groups['master'])
 
  # copy and install yarn-client-api
@@ -121,7 +123,9 @@
     mode: 0700
 
  - name: remove old SSH keys for elyra user
-   local_action: shell rm -rf /tmp/elyra_id_rsa*
+   local_action: file path="{{item}}" state=absent 
+   with_fileglob:
+     - /tmp/elyra_id_rsa*
    run_once: true
 
  - name: generate SSH keys for elyra user
@@ -151,7 +155,9 @@
      key: "{{ lookup('file', '/tmp/elyra_id_rsa.pub') }}"
 
  - name: remove local SSH keys for elyra user
-   local_action: shell rm -rf /tmp/elyra_id_rsa*
+   local_action: file path="{{item}}" state=absent 
+   with_fileglob:
+     - /tmp/elyra_id_rsa*
    run_once: true
 
  - name: create log directory for elyra
@@ -210,8 +216,12 @@
    local_action: get_url url="{{ notebook.elyra_kernelspec_download_location }}{{ notebook.elyra_kernelspec_package_name }}" dest="/tmp/"
    run_once: true
 
- - name: copy toree to remote node
+ - name: create temporary installation directory
+   file:
+     path: "{{ install_temp_dir }}"
+     state: directory
+
+ - name: copy kernelspec package to remote node
    copy:
      src: "/tmp/{{ notebook.elyra_kernelspec_package_name }}"
      dest: "{{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }}"
-   when: (inventory_hostname in groups['master'])

--- a/roles/notebook/tasks/kernel_R.yml
+++ b/roles/notebook/tasks/kernel_R.yml
@@ -12,32 +12,46 @@
  - name: retrieve kernelspec location
    shell: "{{ notebook.jupyter }} kernelspec list | grep -i ir | awk '{print $2}' | xargs -i dirname {}"
    register: result
-   when: (inventory_hostname in groups['master'])
 
  - name: store kernelspec location
    set_fact: jupyter_kernelspec_location="{{ result.stdout }}"
    with_items: "{{ result.stdout }}"
-   when: (inventory_hostname in groups['master'])
 
- - name: remove old kernelspecs for yarn
-   shell: "rm -rf {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+ - name: remove old kernelspecs for yarn cluster
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+     state: absent
+
+ - name: remove old kernelspecs for yarn client
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
+     state: absent
+
+ - name: seed kernelspec location for yarn cluster
+   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: move kernelspec location
-   shell: "mv {{ jupyter_kernelspec_location }}/ir {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+ - name: seed kernelspec location for yarn client
+   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: update kernel launcher
+ - name: remove source kernelspecs location
+   file:
+     path: "{{ jupyter_kernelspec_location }}/ir"
+     state: absent
+
+ - name: update kernel launcher for yarn cluster
    shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/ spark_2.1_R_yarn_cluster/"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: disable impersonation based on configuration
+ - name: update kernel launcher for yarn client
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client/ spark_2.1_R_yarn_client/"
+   ignore_errors: yes
+
+ - name: disable impersonation based on configuration (only applies to cluster mode)
    shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/kernel.json"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master']) and (notebook.enable_impersonation == false)
+   when: (notebook.enable_impersonation == false)
 
 
 

--- a/roles/notebook/tasks/kernel_python.yml
+++ b/roles/notebook/tasks/kernel_python.yml
@@ -1,21 +1,38 @@
 
- - name: remove old yarn kernel launcher
-   shell: "rm -rf {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
-   ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
+ - name: remove old yarn cluster kernel launcher
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
+     state: absent
 
- - name: create placeholder for yarn kernel launcher
-   shell: "mkdir -p {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
-   ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
+ - name: remove old yarn client kernel launcher
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client"
+     state: absent
 
- - name: update kernel launcher
+ - name: create placeholder for yarn cluster kernel launcher
+   file:
+    path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
+    state: directory
+    owner: "{{ notebook.user }}"
+    group: "{{ notebook.user }}"
+
+ - name: create placeholder for yarn client kernel launcher
+   file:
+    path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client"
+    state: directory
+    owner: "{{ notebook.user }}"
+    group: "{{ notebook.user }}"
+
+ - name: update kernel cluster launcher
    shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster spark_2.1_python_yarn_cluster"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: disable impersonation based on configuration
+ - name: update kernel client launcher
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client spark_2.1_python_yarn_client"
+   ignore_errors: yes
+
+ - name: disable impersonation based on configuration (only applies to cluster mode)
    shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster/kernel.json"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master']) and (notebook.enable_impersonation == false)
+   when: (notebook.enable_impersonation == false)
 

--- a/roles/notebook/tasks/kernel_scala.yml
+++ b/roles/notebook/tasks/kernel_scala.yml
@@ -10,17 +10,14 @@
    copy:
      src: "/tmp/{{ notebook.toree_archive_package_name }}"
      dest: "{{ install_temp_dir }}/{{ notebook.toree_archive_package_name }}"
-   when: (inventory_hostname in groups['master'])
 
  - name: pip uninstall toree
    shell: "{{ notebook.pip }} uninstall -y {{ notebook.toree_archive_package_name }}"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
  - name: pip install toree
    shell: "{{ notebook.pip }} install --upgrade {{ install_temp_dir }}/{{notebook.toree_archive_package_name}}"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
  - debug:
     msg: "{{ notebook.jupyter }} toree install --spark_home={{ notebook.spark_home}} --kernel_name=\"Spark 2.1\" --interpreters=Scala"
@@ -29,34 +26,47 @@
    shell: >
     {{ notebook.jupyter }} toree install --spark_home={{ notebook.spark_home}} --kernel_name="Spark 2.1" --interpreters=Scala
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
  - name: retrieve kernelspec location
    shell: "/opt/anaconda2/bin/jupyter kernelspec list | grep -w spark_2.1_scala | awk '{print $2}' | xargs -i dirname {}"
    register: result
-   when: (inventory_hostname in groups['master'])
 
  - name: store kernelspec location
    set_fact: jupyter_kernelspec_location="{{ result.stdout }}"
    with_items: "{{ result.stdout }}"
-   when: (inventory_hostname in groups['master'])
 
- - name: remove old kernelspecs for yarn
-   shell: "rm -rf {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
+ - name: remove old kernelspecs for yarn cluster
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
+     state: absent
+
+ - name: remove old kernelspecs for yarn client
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client"
+     state: absent
+
+ - name: seed kernelspec location for yarn cluster
+   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: move kernelspec location
-   shell: "mv {{ jupyter_kernelspec_location }}/spark_2.1_scala {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
+ - name: seed kernelspec location for yarn client
+   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: update kernel launcher
+ - name: remove source kernelspecs location
+   file:
+     path: "{{ jupyter_kernelspec_location }}/spark_2.1_scala"
+     state: absent
+
+ - name: update kernel launcher for yarn cluster
    shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster/ spark_2.1_scala_yarn_cluster/"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
 
- - name: disable impersonation based on configuration
+ - name: update kernel launcher for yarn client
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client/ spark_2.1_scala_yarn_client/"
+   ignore_errors: yes
+
+ - name: disable impersonation based on configuration (only applies to cluster mode)
    shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster/kernel.json"
    ignore_errors: yes
-   when: (inventory_hostname in groups['master']) and (notebook.enable_impersonation == false)
+   when: (notebook.enable_impersonation == false)

--- a/setup-ambari-cluster.yml
+++ b/setup-ambari-cluster.yml
@@ -13,7 +13,7 @@
     - role: iop
 
 - name: anaconda
-  hosts: master
+  hosts: all
   vars:
     anaconda:
       python_version: 2


### PR DESCRIPTION
This change installs the set of kernelspecs (one for each language) to an elyra deployment.  The primary change is that yarn-client mode (aka, StandaloneProcessProxy) requires that the supporting files of the associated kernelspec (i.e., run.sh, launcher scirpts or jars, etc.) be present on all nodes - and in the same location as the elyra server.

Also, added the ability to specify the root directory on the download server so that alternate deployments can be used.  

Note: This change installs anaconda onto all nodes.  We may need to revisit that later.