### PR TITLE
add optional deploy of kernelspecs to workers

### DIFF
--- a/roles/notebook/defaults/main.yml
+++ b/roles/notebook/defaults/main.yml
@@ -16,7 +16,6 @@ notebook:
   elyra_install_directory: "{{ internal.elyra_install_dir }}"
   elyra_log_directory: "{{ internal.elyra_install_dir }}/log"
   elyra_runtime_directory: "{{ internal.elyra_install_dir }}/runtime"
-  elyra_data_directory: "{{ internal.elyra_install_dir }}/data"
 
   elyra_kernelspec_package_name: elyra-kernel-specs.tar.gz
   elyra_kernelspec_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra-kernel-specs/
@@ -38,3 +37,4 @@ notebook:
 
   enable_impersonation: false
   enable_notebook_5_1: true
+  deploy_kernelspecs_to_workers: false

--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -62,17 +62,6 @@
 
  # Create Elyra user
 
- - name: remove elyra data directory
-   file:
-     path: "{{ notebook.elyra_data_directory }}"
-     state: absent
-   when: (inventory_hostname in groups['master'])
-
- - name: remove elyra runtime directory
-   file:
-    path: "{{ notebook.elyra_runtime_directory }}"
-    state: absent
-
  - name: remove elyra user
    user:
       name: "{{ notebook.user }}"
@@ -150,6 +139,7 @@
      mode: 0755
    become_user: "{{ notebook.user }}"
    ignore_errors: yes
+   when: (inventory_hostname in groups['master'])
 
  - name: create bin directory for elyra
    file:
@@ -168,8 +158,10 @@
     state: directory
     owner: "{{ notebook.user }}"
     group: "{{ notebook.user }}"
-    mode: 0777
+    mode: 0755
    become_user: "{{ notebook.user }}"
+   ignore_errors: yes
+   when: (inventory_hostname in groups['master'])
 
  - name: create data directory for elyra
    file:
@@ -206,8 +198,10 @@
    file:
      path: "{{ install_temp_dir }}"
      state: directory
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true) 
 
  - name: copy kernelspec package to remote node
    copy:
      src: "/tmp/{{ notebook.elyra_kernelspec_package_name }}"
      dest: "{{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }}"
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true) 

--- a/roles/notebook/tasks/kernel_R.yml
+++ b/roles/notebook/tasks/kernel_R.yml
@@ -42,21 +42,25 @@
    file:
      path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
      state: absent
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: remove old R kernelspecs for yarn client
    file:
      path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
      state: absent
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: remove old R kernelspecs for yarn cluster
    file:
      path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
      state: directory
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: remove old R kernelspecs for yarn client
    file:
      path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
      state: directory
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
 # - name: seed R kernelspec location for yarn cluster
 #   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
@@ -70,19 +74,22 @@
    file:
      path: "{{ jupyter_kernelspec_location }}/ir"
      state: absent
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: update kernel launcher for yarn cluster
    shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/ spark_2.1_R_yarn_cluster/"
    ignore_errors: yes
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: update kernel launcher for yarn client
    shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client/ spark_2.1_R_yarn_client/"
    ignore_errors: yes
+   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: disable impersonation based on configuration (only applies to cluster mode)
    shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/kernel.json"
    ignore_errors: yes
-   when: (notebook.enable_impersonation == false)
+   when: (notebook.enable_impersonation == false) and ((inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true))
 
 
 

--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -23,7 +23,13 @@
   when: not notebook.use_anaconda
 
 - include: dependencies.yml
+
 - include: gateway.yml
+
 - include: kernel_scala.yml
+  when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true) 
+
 - include: kernel_python.yml
+  when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true) 
+
 - include: kernel_R.yml

--- a/roles/notebook/templates/start-elyra.sh.j2
+++ b/roles/notebook/templates/start-elyra.sh.j2
@@ -11,12 +11,9 @@ export ELYRA_REMOTE_USER={{ notebook.user }}
 
 export ELYRA_YARN_ENDPOINT=http://{{ notebook.yarn_endpoint_host }}:8088/ws/v1/cluster
 
-export ELYRA_PROXY_LAUNCH_LOG={{ notebook.elyra_log_directory }}/proxy_launch_$(timestamp).log
+export ELYRA_PROXY_LAUNCH_LOG=/tmp/proxy_launch_$(timestamp).log
 
 export ELYRA_KERNEL_LAUNCH_TIMEOUT=40
-
-export JUPYTER_DATA_DIR={{ notebook.elyra_data_directory }}
-export JUPYTER_RUNTIME_DIR={{ notebook.elyra_runtime_directory }}
 
 START_CMD="{{ jupyter }} kernelgateway --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=600 --MappingKernelManager.cull_interval=30 --MappingKernelManager.cull_connected=True --JupyterWebsocketPersonality.list_kernels=True"
 


### PR DESCRIPTION
Added variable to determine if kernelspecs should be deployed to worker nodes: `notebook.deploy_kernelspecs_to_workers`.
Removed use/creation of data directory: /opt/elyra/data
Don't create /opt/elyra on worker nodes.