### PR TITLE
split elyra from jkg

### DIFF
--- a/hosts-elyra-fyi
+++ b/hosts-elyra-fyi
@@ -1,0 +1,19 @@
+[all:vars]
+ansible_connection=ssh
+#ansible_user=root
+#ansible_ssh_private_key_file=~/.ssh/ibm_rsa
+gather_facts=True
+gathering=smart
+host_key_checking=False
+install_temp_dir=/tmp/ansible-install
+install_dir=/opt
+python_version=2
+
+[master]
+elyra-fyi-node-1   ansible_host=9.30.250.232
+
+[nodes]
+elyra-fyi-node-2   ansible_host=9.30.252.8
+elyra-fyi-node-3   ansible_host=9.30.254.115
+elyra-fyi-node-4   ansible_host=9.30.255.217
+elyra-fyi-node-5   ansible_host=9.30.255.220

--- a/hosts-elyra-omg
+++ b/hosts-elyra-omg
@@ -1,0 +1,18 @@
+[all:vars]
+ansible_connection=ssh
+#ansible_user=root
+#ansible_ssh_private_key_file=~/.ssh/ibm_rsa
+gather_facts=True
+gathering=smart
+host_key_checking=False
+install_temp_dir=/tmp/ansible-install
+install_dir=/opt
+
+[master]
+elyra-omg-node-1   ansible_host=9.30.245.178
+
+[nodes]
+elyra-omg-node-2   ansible_host=9.30.192.57
+elyra-omg-node-3   ansible_host=9.30.193.25
+elyra-omg-node-4   ansible_host=9.30.56.40
+elyra-omg-node-5   ansible_host=9.30.57.154

--- a/roles/notebook/defaults/main.yml
+++ b/roles/notebook/defaults/main.yml
@@ -7,10 +7,7 @@ internal:
 
 notebook:
 
-  yarn_client_package_name: yarn_api_client-0.2.4-py2.py3-none-any.whl
-  yarn_client_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/yarn-api-client/
-
-  elyra_archive_package_name: jupyter_kernel_gateway-2.0.0.dev-py2.py3-none-any.whl
+  elyra_archive_package_name: elyra-0.0.2.dev-py2.py3-none-any.whl
   elyra_archive_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra/
 
   elyra_install_directory: "{{ internal.elyra_install_dir }}"

--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -163,17 +163,6 @@
    ignore_errors: yes
    when: (inventory_hostname in groups['master'])
 
- - name: create data directory for elyra
-   file:
-     path: "{{ notebook.elyra_data_directory }}"
-     state: directory
-     owner: "{{ notebook.user }}"
-     group: "{{ notebook.user }}"
-     mode: 0755
-   become_user: "{{ notebook.user }}"
-   ignore_errors: yes
-   when: (inventory_hostname in groups['master'])
-
  - name: generate elyra startup script
    template:
     src: start-elyra.sh.j2

--- a/roles/notebook/templates/start-elyra.sh.j2
+++ b/roles/notebook/templates/start-elyra.sh.j2
@@ -11,11 +11,11 @@ export ELYRA_REMOTE_USER={{ notebook.user }}
 
 export ELYRA_YARN_ENDPOINT=http://{{ notebook.yarn_endpoint_host }}:8088/ws/v1/cluster
 
-export ELYRA_PROXY_LAUNCH_LOG=/var/log/elyra_proxy_launch_$(timestamp).log
+export ELYRA_PROXY_LAUNCH_LOG=/tmp/elyra_proxy_launch_$(timestamp).log
 
 export ELYRA_KERNEL_LAUNCH_TIMEOUT=40
 
-START_CMD="{{ jupyter }} kernelgateway --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=600 --MappingKernelManager.cull_interval=30 --MappingKernelManager.cull_connected=True --JupyterWebsocketPersonality.list_kernels=True"
+START_CMD="{{ jupyter }} elyra --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=600 --MappingKernelManager.cull_interval=30 --MappingKernelManager.cull_connected=True --JupyterWebsocketPersonality.list_kernels=True"
 
 LOG_FORMAT=--KernelGatewayApp.log_format='%(asctime)s,%(msecs)03d %(levelname)s %(name)s: %(message)s'
 

--- a/setup-elyra-cluster.yml
+++ b/setup-elyra-cluster.yml
@@ -1,0 +1,19 @@
+
+#- name: anaconda
+#  hosts: all
+#  vars:
+#    anaconda:
+#      python_version: 2
+#      update_path: false
+#  remote_user: root
+#  roles:
+#   - role: anaconda
+
+- name: notebook platform dependencies
+  hosts: all
+  vars:
+    notebook:
+      use_anaconda: true
+  remote_user: root
+  roles:
+    - role: notebook


### PR DESCRIPTION
Changes necessary to reference the elyra artifacts that have now been split from JKG.
Fixed issue where the proxy launch log was using /var/log instead of /tmp, but /var/log is only writable (on HDP at least) by root - so I reverted back to using /tmp until further notice.
Also removed reference to the data directory - that should have been removed in previous change.

Note that this PR should not be merged until the corresponding PR is merged in the Elyra project.
