### PR TITLE
Update kernelspecs tar, wheel filenames. Remove notebook 5.1 one-off code

### DIFF
--- a/roles/notebook/defaults/main.yml
+++ b/roles/notebook/defaults/main.yml
@@ -7,18 +7,15 @@ internal:
 
 notebook:
 
-  elyra_archive_package_name: elyra-0.0.2.dev-py2.py3-none-any.whl
+  elyra_archive_package_name: elyra-0.0.2.dev0-py2.py3-none-any.whl
   elyra_archive_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra/
 
   elyra_install_directory: "{{ internal.elyra_install_dir }}"
   elyra_log_directory: "{{ internal.elyra_install_dir }}/log"
   elyra_runtime_directory: "{{ internal.elyra_install_dir }}/runtime"
 
-  elyra_kernelspec_package_name: elyra-kernel-specs.tar.gz
-  elyra_kernelspec_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra-kernel-specs/
-
-  notebook_archive_package_name: notebook-5.1.0.dev0-py2.py3-none-any.whl
-  notebook_archive_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/notebook/
+  elyra_kernelspec_package_name: elyra-kernelspecs.tar.gz
+  elyra_kernelspec_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/elyra-kernelspecs/
 
   toree_archive_package_name: toree-0.2.0.dev1.tar.gz
   toree_pip_download_location: http://{{ internal.elyra_download_server }}/{{ internal.elyra_download_root }}/toree/
@@ -33,5 +30,4 @@ notebook:
   groups: [hdfs]
 
   enable_impersonation: false
-  enable_notebook_5_1: true
   deploy_kernelspecs_to_workers: false

--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -35,31 +35,6 @@
    shell: "{{ pip }} install {{ install_temp_dir }}/{{ notebook.elyra_archive_package_name }}"
    when: (inventory_hostname in groups['master'])
 
- # copy and install notebook - this must follow the elyra (JKG) install until it pulls Notebook 5.1.0
-
- - debug:
-    msg: "Downloading Notebook: {{ notebook.notebook_archive_pip_download_location }}{{ notebook.notebook_archive_package_name }}"
-
- - name: download and install notebook
-   local_action: get_url url="{{ notebook.notebook_archive_pip_download_location }}{{ notebook.notebook_archive_package_name }}" dest="/tmp/"
-   when: (inventory_hostname in groups['master']) and (notebook.enable_notebook_5_1 == true)
-   run_once: true
-
- - name: copy notebook to node
-   copy:
-     src: "/tmp/{{ notebook.notebook_archive_package_name }}"
-     dest: "{{ install_temp_dir }}/{{ notebook.notebook_archive_package_name }}"
-   when: (inventory_hostname in groups['master']) and (notebook.enable_notebook_5_1 == true)
-
- - name: pip uninstall notebook
-   shell: "{{ pip }} uninstall -y {{ notebook.notebook_archive_package_name }}"
-   ignore_errors: yes
-   when: (inventory_hostname in groups['master']) and (notebook.enable_notebook_5_1 == true)
-
- - name: pip install notebook
-   shell: "{{ pip }} install {{ install_temp_dir }}/{{ notebook.notebook_archive_package_name }}"
-   when: (inventory_hostname in groups['master']) and (notebook.enable_notebook_5_1 == true)
-
  # Create Elyra user
 
  - name: remove elyra user


### PR DESCRIPTION
Recent updates have lead to changes within the scripts for the following...
1. The elyra wheel file contains `dev0` per the python specification, old name was just ...`dev`...
2. The kernelspecs tar filename and download location has been updated to remove the `-` from `kernel-specs`.  New location: `elyra-kernelspecs`, New tar file: `elyra-kernelspecs.tar.gz`.
3. Notebook 5.1.0 has been GA'd and dependencies updated.  As a result, we don't need special one-off code to handle installation of Notebook 5.1.0.

These updates have been tested against `elyra-omg-node-1.fyre.ibm.com` (consists of nodes 1 - 5)

Please merge only after https://github.com/SparkTC/elyra/pull/147 has been merged.
