### PR TITLE
Update README.md with information to deploy kernelspecs automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ FQDN   ansible_host=IP
 
 ```
 
+### Automatic Deployment of KernelSpecs on Cluster/Worker Nodes
+You can optionally deploy kernelspecs for Python, R, and Scala
+automatically on the cluster nodes by editing
+`spark-cluster-install/roles/notebook/default/main.yml` file such
+that `deploy_kernelspecs_to_workers` is set to `true` as shown
+below:
+
+```
+  deploy_kernelspecs_to_workers: true
+```
+
 ### Deploy
 
 ```


### PR DESCRIPTION
Python, R, and Scala kernelspecs will be automatically deployed as part of executing the Ansible playbook.