### PR TITLE
[WIP] Enable remote deployment of Enterprise Gateway

### DIFF
--- a/roles/notebook/tasks/gateway.yml
+++ b/roles/notebook/tasks/gateway.yml
@@ -16,7 +16,7 @@
     msg: "Downloading Elyra: {{ notebook.elyra_archive_pip_download_location }}{{ notebook.elyra_archive_package_name }}"
 
  - name: download and install elyra
-   local_action: get_url url="{{ notebook.elyra_archive_pip_download_location }}{{ notebook.elyra_archive_package_name }}" dest="/tmp"
+   get_url: url="{{ notebook.elyra_archive_pip_download_location }}{{ notebook.elyra_archive_package_name }}" dest="/tmp"
    when: (inventory_hostname in groups['master'])
    run_once: true
 
@@ -71,30 +71,38 @@
     mode: 0700
 
  - name: remove old SSH keys for elyra user
-   local_action: file path="{{item}}" state=absent 
+   file: path="{{item}}" state=absent
    with_fileglob:
      - /tmp/elyra_id_rsa*
    run_once: true
+   when: inventory_hostname in groups['master']
 
  - name: generate SSH keys for elyra user
-   local_action: shell ssh-keygen -t rsa -b 4096 -f /tmp/elyra_id_rsa -q -N ""
+   shell: ssh-keygen -t rsa -b 4096 -f /tmp/elyra_id_rsa -q -N ""
    run_once: true
+   when: inventory_hostname in groups['master']
 
  - name: copy private ssh key to node
    copy:
+     remote_src: True
      src: "/tmp/elyra_id_rsa"
      dest: "/home/{{ notebook.user }}/.ssh/id_rsa"
      owner: "{{ notebook.user }}"
      group: "{{ notebook.user }}"
      mode: 0600
+   run_once: true
+   when: inventory_hostname in groups['master']
 
  - name: copy public ssh key to node
    copy:
+     remote_src: True
      src: "/tmp/elyra_id_rsa.pub"
      dest: "/home/{{ notebook.user }}/.ssh/id_rsa.pub"
      owner: "{{ notebook.user }}"
      group: "{{ notebook.user }}"
      mode: 0644
+   run_once: true
+   when: inventory_hostname in groups['master']
 
  - name: add SSH key to authorized users
    authorized_key:
@@ -103,10 +111,11 @@
      key: "{{ lookup('file', '/tmp/elyra_id_rsa.pub') }}"
 
  - name: remove local SSH keys for elyra user
-   local_action: file path="{{item}}" state=absent 
+   file: path="{{item}}" state=absent
    with_fileglob:
      - /tmp/elyra_id_rsa*
    run_once: true
+   when: inventory_hostname in groups['master']
 
  - name: Remove elyra root installation folder
    file:


### PR DESCRIPTION
When running the playbook `setup-enterprise-gateway.yml` from my Mac to setup Enterprise Gateway on a remote Ambari cluster, it fails the (see Issue #20).

I have been debugging through a few of the failing tasks and started to to make changes to ensure the tasks like generating SSH keys are actually executed on the remote `master` node, not on my local Mac.

So far I got these tasks working remotely:
  - [x] `name: download and install elyra`
  - [x] `name: remove old SSH keys for elyra user`
  - [x] `name: generate SSH keys for elyra user`
  - [x] `name: copy private ssh key to node`
  - [x] `name: copy public ssh key to node`
  - [x] `name: remove local SSH keys for elyra user`

Further changes are need from this task onward:
  - [ ] `name: add SSH key to authorized users` (I did not find out how/if this can run on a remote host)
  - [ ] ...

The only action that may justifiably have to run "locally" may be the `download and install elyra` task since those files require a special VPN connection to download. Once there is a [PyPI install package](https://pypi.python.org/pypi/jupyter_enterprise_gateway) available, that restricted download won't be necessary any longer.