### PR TITLE
Remove spark version indicator in kernelspecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ roles/test/**
 test.yml
 hosts-test
 
+hosts-elyra-fyi
+hosts-elyra-omg
+

--- a/roles/anaconda/tasks/main.yml
+++ b/roles/anaconda/tasks/main.yml
@@ -16,6 +16,17 @@
     state: absent
     path: "{{ install_dir }}/anaconda3/"
 
+- name: remove old temporary install dir
+  file:
+    path: "{{ install_temp_dir }}"
+    state: absent
+
+- name: create temporary install dir
+  file:
+    path: "{{ install_temp_dir }}"
+    state: directory
+    mode: 0755
+
 - debug:
      msg: "Downloading https://repo.continuum.io/archive/{{ anaconda_install_file }}"
 

--- a/roles/notebook/tasks/kernel_R.yml
+++ b/roles/notebook/tasks/kernel_R.yml
@@ -44,34 +44,34 @@
 
  - name: remove old R kernelspecs for yarn cluster
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+     path: "{{ jupyter_kernelspec_location }}/spark_R_yarn_cluster"
      state: absent
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: remove old R kernelspecs for yarn client
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
+     path: "{{ jupyter_kernelspec_location }}/spark_R_yarn_client"
      state: absent
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
- - name: remove old R kernelspecs for yarn cluster
+ - name: create R kernelspecs directory for yarn cluster
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+     path: "{{ jupyter_kernelspec_location }}/spark_R_yarn_cluster"
      state: directory
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
- - name: remove old R kernelspecs for yarn client
+ - name: create R kernelspecs directory for yarn client
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
+     path: "{{ jupyter_kernelspec_location }}/spark_R_yarn_client"
      state: directory
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
 # - name: seed R kernelspec location for yarn cluster
-#   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster"
+#   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_R_yarn_cluster"
 #   ignore_errors: yes
 
 # - name: seed R kernelspec location for yarn client
-#   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client"
+#   shell: "cp -r {{ jupyter_kernelspec_location }}/ir/ {{ jupyter_kernelspec_location }}/spark_R_yarn_client"
 #   ignore_errors: yes
 
  - name: remove source R kernelspecs location
@@ -81,19 +81,17 @@
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: update kernel launcher for yarn cluster
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/ spark_2.1_R_yarn_cluster/"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_R_yarn_cluster/ spark_R_yarn_cluster/"
    ignore_errors: yes
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: update kernel launcher for yarn client
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_client/ spark_2.1_R_yarn_client/"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_R_yarn_client/ spark_R_yarn_client/"
    ignore_errors: yes
    when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)
 
  - name: disable impersonation based on configuration (only applies to cluster mode)
-   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_R_yarn_cluster/kernel.json"
+   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_R_yarn_cluster/kernel.json"
    ignore_errors: yes
    when: (notebook.enable_impersonation == false) and ((inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true))
-
-
 

--- a/roles/notebook/tasks/kernel_python.yml
+++ b/roles/notebook/tasks/kernel_python.yml
@@ -1,38 +1,38 @@
 
  - name: remove old python yarn cluster kernel launcher
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
+     path: "{{ jupyter_kernelspec_location }}/spark_python_yarn_cluster"
      state: absent
 
  - name: remove old python yarn client kernel launcher
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client"
+     path: "{{ jupyter_kernelspec_location }}/spark_python_yarn_client"
      state: absent
 
  - name: create placeholder for python yarn cluster kernel launcher
    file:
-    path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster"
+    path: "{{ jupyter_kernelspec_location }}/spark_python_yarn_cluster"
     state: directory
     owner: "{{ notebook.user }}"
     group: "{{ notebook.user }}"
 
  - name: create placeholder for python yarn client kernel launcher
    file:
-    path: "{{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client"
+    path: "{{ jupyter_kernelspec_location }}/spark_python_yarn_client"
     state: directory
     owner: "{{ notebook.user }}"
     group: "{{ notebook.user }}"
 
  - name: update python kernel cluster launcher
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster spark_2.1_python_yarn_cluster"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_python_yarn_cluster spark_python_yarn_cluster"
    ignore_errors: yes
 
  - name: update python kernel client launcher
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_client spark_2.1_python_yarn_client"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_python_yarn_client spark_python_yarn_client"
    ignore_errors: yes
 
  - name: disable impersonation based on configuration (only applies to cluster mode)
-   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_python_yarn_cluster/kernel.json"
+   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_python_yarn_cluster/kernel.json"
    ignore_errors: yes
    when: (notebook.enable_impersonation == false)
 

--- a/roles/notebook/tasks/kernel_scala.yml
+++ b/roles/notebook/tasks/kernel_scala.yml
@@ -37,20 +37,20 @@
 
  - name: remove old kernelspecs for yarn cluster
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
+     path: "{{ jupyter_kernelspec_location }}/spark_scala_yarn_cluster"
      state: absent
 
  - name: remove old kernelspecs for yarn client
    file:
-     path: "{{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client"
+     path: "{{ jupyter_kernelspec_location }}/spark_scala_yarn_client"
      state: absent
 
  - name: seed kernelspec location for yarn cluster
-   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster"
+   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_scala_yarn_cluster"
    ignore_errors: yes
 
  - name: seed kernelspec location for yarn client
-   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client"
+   shell: "cp -r {{ jupyter_kernelspec_location }}/spark_2.1_scala/ {{ jupyter_kernelspec_location }}/spark_scala_yarn_client"
    ignore_errors: yes
 
  - name: remove source kernelspecs location
@@ -59,14 +59,14 @@
      state: absent
 
  - name: update kernel launcher for yarn cluster
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster/ spark_2.1_scala_yarn_cluster/"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/"
    ignore_errors: yes
 
  - name: update kernel launcher for yarn client
-   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_client/ spark_2.1_scala_yarn_client/"
+   shell: "tar -zxvf {{ install_temp_dir }}/{{ notebook.elyra_kernelspec_package_name }} --strip 1 --directory {{ jupyter_kernelspec_location }}/spark_scala_yarn_client/ spark_scala_yarn_client/"
    ignore_errors: yes
 
  - name: disable impersonation based on configuration (only applies to cluster mode)
-   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_2.1_scala_yarn_cluster/kernel.json"
+   shell: " sed -i 's/ --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}//g' {{ jupyter_kernelspec_location }}/spark_scala_yarn_cluster/kernel.json"
    ignore_errors: yes
    when: (notebook.enable_impersonation == false)

--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -49,3 +49,4 @@
   when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true) 
 
 - include: kernel_R.yml
+  when: (inventory_hostname in groups['master']) or (notebook.deploy_kernelspecs_to_workers == true)

--- a/roles/notebook/templates/start-elyra.sh.j2
+++ b/roles/notebook/templates/start-elyra.sh.j2
@@ -7,19 +7,16 @@ timestamp() {
 unset XDG_RUNTIME_DIR
 export EG_REMOTE_HOSTS={{ hostvars.values()|map(attribute='inventory_hostname')|join(',') }}
 export EG_REMOTE_USER={{ notebook.user }}
-# provide password if passwordless ssh is not configured
-#export EG_REMOTE_PWD=
 
 export EG_YARN_ENDPOINT=http://{{ notebook.yarn_endpoint_host }}:8088/ws/v1/cluster
 
-export EG_PROXY_LAUNCH_LOG=/tmp/elyra_proxy_launch_$(timestamp).log
-
 export EG_KERNEL_LAUNCH_TIMEOUT=40
 
-START_CMD="{{ jupyter }} enterprisegateway --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=600 --MappingKernelManager.cull_interval=30 --MappingKernelManager.cull_connected=True --JupyterWebsocketPersonality.list_kernels=True"
+# Note: The culling parameters will cull idle kernels after 12 hours (43200 secs).  Update according to your requirements.
+START_CMD="{{ jupyter }} enterprisegateway --ip=0.0.0.0 --port=8888 --port_retries=0 --log-level=DEBUG --MappingKernelManager.cull_idle_timeout=43200 --MappingKernelManager.cull_interval=60 --MappingKernelManager.cull_connected=True"
 
 # Enable white list of kernels...
-#WHITE_LIST=--KernelSpecManager.whitelist="['spark_2.1_python_yarn_cluster','spark_2.1_r_yarn_cluster','spark_2.1_scala_yarn_cluster','spark_2.1_python_yarn_client','spark_2.1_r_yarn_client','spark_2.1_scala_yarn_client']"
+#WHITE_LIST=--KernelSpecManager.whitelist="['spark_python_yarn_cluster','spark_r_yarn_cluster','spark_scala_yarn_cluster','spark_python_yarn_client','spark_r_yarn_client','spark_scala_yarn_client']"
 
 LOG={{ notebook.elyra_log_directory }}/enterprise_gateway_$(timestamp).log
 PIDFILE={{ notebook.elyra_runtime_directory }}/enterprise_gateway.pid


### PR DESCRIPTION
Removed spark version (`2.1`) indicator from the kernelspec directory
names and updated the whitelist example in the start script with new
kernel names.

Also removed some unused or unnecessary variables from start script
and changed culling to the increased recommended value of 12 hours with
note that it should be changed to desired requirements.

Fixed a couple general items in the scripts.